### PR TITLE
Corrected url for librest

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -182,7 +182,7 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://git.gnome.org/browse/librest/snapshot/librest-0.8.1.tar.xz",
+                    "url" : "https://gitlab.gnome.org/GNOME/librest/snapshot/librest-0.8.1.tar.xz",
                     "sha256" : "8ae2d5b993b568d87fb33767cdf43dc81aa36371351e9154680372e1536fb594"
                 }
             ]


### PR DESCRIPTION
URL for `librest` was incorrect and was unable to build. URL has been modified and now directs to the required tarball.