### PR TITLE
Wrong librest url

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -182,7 +182,7 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://git.gnome.org/browse/librest/snapshot/librest-0.8.1.tar.xz",
+                    "url" : "https://gitlab.gnome.org/GNOME/librest/snapshot/librest-0.8.1.tar.xz",
                     "sha256" : "8ae2d5b993b568d87fb33767cdf43dc81aa36371351e9154680372e1536fb594"
                 }
             ]

--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -182,7 +182,7 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.gnome.org/GNOME/librest/snapshot/librest-0.8.1.tar.xz",
+                    "url" : "https://gitlab.gnome.org/GNOME/librest/-/archive/0.8.1/librest-0.8.1.tar.gz",
                     "sha256" : "8ae2d5b993b568d87fb33767cdf43dc81aa36371351e9154680372e1536fb594"
                 }
             ]


### PR DESCRIPTION
URL for `librest` was pointing to some git repo instead due to which it was not possible to build it. Now it points to the correct URL.